### PR TITLE
Use Solid to call locateSerialPort when devices are added or removed

### DIFF
--- a/testclient/CMakeLists.txt
+++ b/testclient/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(CMAKE_AUTOUIC ON)
 
+find_package(KF5Solid)
+
 include_directories(../src)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
@@ -11,4 +13,4 @@ set(AtCoreTestClient_SRCS
 add_executable(AtCoreTest ${AtCoreTestClient_SRCS})
 add_dependencies(AtCoreTest AtCoreLib)
 
-target_link_libraries(AtCoreTest AtCoreLib Qt5::Widgets)
+target_link_libraries(AtCoreTest AtCoreLib Qt5::Widgets KF5::Solid)

--- a/testclient/mainwindow.cpp
+++ b/testclient/mainwindow.cpp
@@ -10,6 +10,8 @@
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
+    core(new AtCore(this)),
+    deviceNotifier(Solid::DeviceNotifier::instance()),
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
@@ -17,8 +19,6 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->baudRateLE->setValidator(validator);
     ui->baudRateLE->setText("115200");
     addLog(tr("Attempting to locate Serial Ports"));
-
-    core = new AtCore(this);
 
     locateSerialPort();
 
@@ -34,6 +34,8 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->mvAxisPB, &QPushButton::clicked, this, &MainWindow::mvAxisPBClicked);
     connect(ui->fanSpeedPB, &QPushButton::clicked, this, &MainWindow::fanSpeedPBClicked);
     connect(ui->printPB, &QPushButton::clicked, this, &MainWindow::printPBClicked);
+    connect(deviceNotifier, &Solid::DeviceNotifier::deviceAdded, this, &MainWindow::locateSerialPort);
+    connect(deviceNotifier, &Solid::DeviceNotifier::deviceRemoved, this, &MainWindow::locateSerialPort);
 }
 
 MainWindow::~MainWindow()
@@ -113,6 +115,8 @@ void MainWindow::locateSerialPort()
             addLog(tr("Found %1 Ports").arg(QString::number(serialPortList.count())));
         }
     } else {
+        serialPortList.clear();
+        ui->serialPortCB->clear();
         addLog(tr("Not available ports! Please connect a serial device to continue!"));
     }
 }

--- a/testclient/mainwindow.h
+++ b/testclient/mainwindow.h
@@ -6,6 +6,8 @@
 #include <QMainWindow>
 #include <QSerialPort>
 
+#include <KF5/Solid/Solid/DeviceNotifier>
+
 class SerialLayer;
 
 class  MainWindow: public QMainWindow
@@ -91,6 +93,7 @@ private:
     Ui::MainWindow *ui;
     AtCore *core;
     QStringList serialPortList;
+    Solid::DeviceNotifier *deviceNotifier;
 
     /**
      * @brief Locate serial port


### PR DESCRIPTION
Connect Solid::DeviceNotifier::deviceAdded and Solid::DeviceNotifier::deviceRemoved to MainWindow::locateSerialPort

Signed-off-by: Chris Rizzitello sithlord48@gmail.com
