### PR TITLE
Add option to manually select the firmware plugin

### DIFF
--- a/src/atcore.h
+++ b/src/atcore.h
@@ -73,6 +73,18 @@ public:
      */
     float percentagePrinted();
 
+    /** 
+     * @brief Request a list of firmware plugins
+     */
+    QStringList availablePlugins();
+
+    /**
+     * @brief Load A firmware
+     *
+     * @param fwName : name of the firmware
+     */
+    void loadFirmware(const QString &fwName);
+
 signals:
     /**
      * @brief Emit signal when the printing precentabe changes.
@@ -98,6 +110,7 @@ private:
     void pushCommand(const QString &comm);
     void newMessage(const QByteArray &message);
     void findFirmware(const QByteArray &message);
+    void findPlugins();
     QByteArray lastMessage;
     AtCorePrivate *d;
     PrinterState printerState;

--- a/testclient/mainwindow.cpp
+++ b/testclient/mainwindow.cpp
@@ -49,6 +49,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(deviceNotifier, &Solid::DeviceNotifier::deviceAdded, this, &MainWindow::locateSerialPort);
     connect(deviceNotifier, &Solid::DeviceNotifier::deviceRemoved, this, &MainWindow::locateSerialPort);
     connect(core, &AtCore::printProgressChanged, ui->printingProgress, &QProgressBar::setValue);
+    connect(ui->pluginCB, &QComboBox::currentTextChanged, this , &MainWindow::pluginCBChanged);
 }
 
 MainWindow::~MainWindow()
@@ -304,4 +305,12 @@ void MainWindow::saveLogPBClicked()
     QString saveFileName = QFileDialog::getSaveFileName(this, tr("Save Log to file"), fileName);
     QFile::copy(logFile->fileName(), saveFileName);
     logFile->close();
+}
+void MainWindow::pluginCBChanged(QString currentText)
+{
+    if (core->state() != DISCONNECTED) {
+        if (!currentText.contains(tr("Autodetect"))) {
+            core->loadFirmware(currentText);
+        }
+    }
 }

--- a/testclient/mainwindow.cpp
+++ b/testclient/mainwindow.cpp
@@ -21,6 +21,10 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->serialPortCB->setEditable(true);
     ui->baudRateLE->setValidator(validator);
     ui->baudRateLE->setText(QStringLiteral("115200"));
+
+    ui->pluginCB->addItem(tr("Autodetect"));
+    ui->pluginCB->addItems(core->availablePlugins());
+
     addLog(tr("Attempting to locate Serial Ports"));
 
     //hide the printing progress bar.
@@ -161,9 +165,13 @@ void MainWindow::connectPBClicked()
         addLog(tr("Serial connected"));
         ui->connectPB->setText(tr("Disconnect"));
         if (!core->pluginLoaded()) {
-            addLog(tr("No plugin loaded !"));
-            addLog(tr("Requesting Firmware..."));
-            core->requestFirmware();
+            if (ui->pluginCB->currentText().contains(tr("Autodetect"))) {
+                addLog(tr("No plugin loaded !"));
+                addLog(tr("Requesting Firmware..."));
+                core->requestFirmware();
+            } else {
+                core->loadFirmware(ui->pluginCB->currentText());
+            }
         }
     } else {
         core->serial()->closeConnection();
@@ -246,15 +254,10 @@ void MainWindow::printPBClicked()
 
     case DISCONNECTED:
         QMessageBox::information(this, tr("Error"), tr("Not Connected To a Printer"));
-        if (!core->pluginLoaded()) {
-            addLog(tr("No plugin loaded !"));
-            addLog(tr("Requesting Firmware..."));
-            core->requestFirmware();
-        }
         break;
 
     case CONNECTING:
-        QMessageBox::information(this, tr("Error"), tr("Firmware Plugin not loaded try sending M115"));
+        QMessageBox::information(this, tr("Error"), tr("Firmware Plugin not loaded"));
         break;
 
     case IDLE:

--- a/testclient/mainwindow.h
+++ b/testclient/mainwindow.h
@@ -168,4 +168,9 @@ private:
      * @param  msg: Message
      */
     void addSLog(QString msg);
+
+    /**
+     * @brief pluginCB index changed
+     */
+    void pluginCBChanged(QString currentText);
 };

--- a/testclient/mainwindow.ui
+++ b/testclient/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1239</width>
-    <height>660</height>
+    <width>1237</width>
+    <height>658</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -77,6 +77,27 @@
             </item>
             <item>
              <widget class="QLineEdit" name="baudRateLE"/>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Use Plugin</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="pluginCB">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
adds everything needed to allow the user to select a firmware plugin without running M115.  Due to methods in AtCore and how findFirmware is called manual override will only work for the first connection. This is mainly because of how initFirmware connects the serial device to the findFirmware function. 

This also fixes a crash when print is pressed without being connected to a printer.
