### PR TITLE
More AtCore Slots and Signals

### DIFF
--- a/src/atcore.cpp
+++ b/src/atcore.cpp
@@ -1,6 +1,5 @@
 #include "atcore.h"
 #include "seriallayer.h"
-#include "ifirmware.h"
 #include "gcodecommands.h"
 
 #include <QDir>
@@ -124,6 +123,7 @@ void AtCore::loadFirmware(const QString &fwName)
             qDebug() << "Connected to" << plugin()->name();
             disconnect(serial(), &SerialLayer::receivedCommand, this, &AtCore::findFirmware);
             connect(serial(), &SerialLayer::receivedCommand, this, &AtCore::newMessage);
+            connect(plugin(), &IFirmware::printerStatusChanged, this, &AtCore::statusChanged);
             setState(IDLE);
         }
     } else {
@@ -324,7 +324,14 @@ void AtCore::detectFirmware()
     connect(serial(), &SerialLayer::receivedCommand, this, &AtCore::findFirmware);
     requestFirmware();
 }
+
+void AtCore::statusChanged(const PrinterStatus &newStatus)
+{
+    emit(printerStatusChanged(newStatus));
+}
+
 /*~~~~~Control Slots ~~~~~~~~*/
+
 void AtCore::home()
 {
     pushCommand(GCode::toCommand(GCode::G28));

--- a/src/atcore.cpp
+++ b/src/atcore.cpp
@@ -397,3 +397,27 @@ void AtCore::setFanSpeed(uint speed, uint fanNumber)
 {
     pushCommand(GCode::toCommand(GCode::M106, QString::number(fanNumber), QString::number(speed)));
 }
+
+void AtCore::setPrinterSpeed(uint speed)
+{
+    pushCommand(GCode::toCommand(GCode::M220, QString::number(speed)));
+}
+
+void AtCore::setFlowRate(uint speed)
+{
+    pushCommand(GCode::toCommand(GCode::M221, QString::number(speed)));
+}
+
+void AtCore::move(uchar axis, uint arg)
+{
+    if (axis & X) {
+        pushCommand(GCode::toCommand(GCode::G1, QStringLiteral("X %1").arg(QString::number(arg))));
+    } else if (axis & Y) {
+        pushCommand(GCode::toCommand(GCode::G1, QStringLiteral("Y %1").arg(QString::number(arg))));
+    } else if (axis & Z) {
+        pushCommand(GCode::toCommand(GCode::G1, QStringLiteral("Z %1").arg(QString::number(arg))));
+    } else if (axis & E) {
+        pushCommand(GCode::toCommand(GCode::G1, QStringLiteral("E %1").arg(QString::number(arg))));
+    }
+}
+

--- a/src/atcore.cpp
+++ b/src/atcore.cpp
@@ -324,3 +324,41 @@ void AtCore::detectFirmware()
     connect(serial(), &SerialLayer::receivedCommand, this, &AtCore::findFirmware);
     requestFirmware();
 }
+/*~~~~~Control Slots ~~~~~~~~*/
+void AtCore::home()
+{
+    pushCommand(GCode::toCommand(GCode::G28));
+}
+
+void AtCore::home(uchar axis)
+{
+    QString args;
+
+    if (axis & X) {
+        args.append(QStringLiteral("X0 "));
+    }
+
+    if (axis & Y) {
+        args.append(QStringLiteral("Y0 "));
+    }
+
+    if (axis & Z) {
+        args.append(QStringLiteral("Z0"));
+    }
+    pushCommand(GCode::toCommand(GCode::G28, args));
+}
+
+void AtCore::setExtruderTemp(uint temp, uint extruder)
+{
+    pushCommand(GCode::toCommand(GCode::M104, QString::number(extruder), QString::number(temp)));
+}
+
+void AtCore::setBedTemp(uint temp)
+{
+    pushCommand(GCode::toCommand(GCode::M140, QString::number(temp)));
+}
+
+void AtCore::setFanSpeed(uint speed, uint fanNumber)
+{
+    pushCommand(GCode::toCommand(GCode::M106, QString::number(fanNumber), QString::number(speed)));
+}

--- a/src/atcore.h
+++ b/src/atcore.h
@@ -4,6 +4,8 @@
 #include <QList>
 #include <QSerialPortInfo>
 
+#include "ifirmware.h"
+
 class SerialLayer;
 class IFirmware;
 
@@ -120,7 +122,11 @@ signals:
      */
     void stateChanged(PrinterState newState);
 
+    void printerStatusChanged(const PrinterStatus &newStatus);
+
 public slots:
+    void statusChanged(const PrinterStatus &newStatus);
+
     /**
      * @brief Public Interface for printing a file
      */

--- a/src/atcore.h
+++ b/src/atcore.h
@@ -138,6 +138,16 @@ public slots:
     void stop();
 
     /**
+     * @brief pause an in process print job
+     */
+    void pause();
+
+    /**
+     * @brief resume a paused print job.
+     */
+    void resume();
+
+    /**
      * @brief Send home command
      * @param axis: the axis(es) to home (use X Y Z or any combo of)
      */
@@ -168,6 +178,9 @@ public slots:
      */
     void setFanSpeed(uint speed = 0, uint fanNumber = 0);
 
+    void setAbsolutePosition();
+    void setRelativePosition();
+
 private:
     /**
      * @brief Print a file
@@ -183,4 +196,5 @@ private:
     AtCorePrivate *d;
     PrinterState printerState;
     float percentage;
+    QByteArray posString;
 };

--- a/src/atcore.h
+++ b/src/atcore.h
@@ -20,6 +20,12 @@ enum PrinterState {
 };
 
 struct AtCorePrivate;
+enum AXIS {
+    X = 1 << 0,
+    Y = 1 << 1,
+    Z = 1 << 2,
+    E = 1 << 3,
+};
 
 class AtCore : public QObject
 {
@@ -124,6 +130,37 @@ public slots:
      * @brief Stop the Printer
      */
     void stop();
+
+    /**
+     * @brief Send home command
+     * @param axis: the axis(es) to home (use X Y Z or any combo of)
+     */
+    void home(uchar axis);
+
+    /**
+     * @brief Send home all command
+     */
+    void home();
+
+    /**
+     * @brief Set extruder temperature
+     * @param temp : new temperature
+     * @param extruder : extruder number
+     */
+    void setExtruderTemp(uint temp = 0, uint extruder = 0);
+
+    /**
+     * @brief Set the bed temperature
+     * @param temp : new temperature
+     */
+    void setBedTemp(uint temp = 0);
+
+    /**
+     * @brief setFanSpeed set the fan speed
+     * @param fanNumber: fan number
+     * @param speed: new speed of the fan 0-100
+     */
+    void setFanSpeed(uint speed = 0, uint fanNumber = 0);
 
 private:
     /**

--- a/src/atcore.h
+++ b/src/atcore.h
@@ -166,6 +166,13 @@ public slots:
     void setExtruderTemp(uint temp = 0, uint extruder = 0);
 
     /**
+     * @brief move an axis of the printer
+     * @param axis the axis to move AXIS (X Y Z E )
+     * @param arg the distance to move the axis or the place to move to depending on printer mode
+     */
+    void move(uchar axis, uint arg);
+
+    /**
      * @brief Set the bed temperature
      * @param temp : new temperature
      */
@@ -180,6 +187,18 @@ public slots:
 
     void setAbsolutePosition();
     void setRelativePosition();
+
+    /**
+     * @brief set the Printers speed
+     * @param speed: speed in % (default is 100);
+     */
+    void setPrinterSpeed(uint speed = 100);
+
+    /**
+     * @brief set extruder Flow rate
+     * @parma rate: flow rate in % (default is 100)
+     */
+    void setFlowRate(uint rate = 100);
 
 private:
     /**

--- a/src/gcodecommands.cpp
+++ b/src/gcodecommands.cpp
@@ -91,6 +91,13 @@ QString toString(GCommands gcode)
 QString toCommand(GCommands gcode, const QString &value1)
 {
     switch (gcode) {
+    case G0: {
+        if (value1.isEmpty()) {
+            return QStringLiteral("G0");
+        } else {
+            return QStringLiteral("G0 %1").arg(value1.toUpper());
+        }
+    }
     case G1: {
         if (value1.isEmpty()) {
             return QStringLiteral("G1");

--- a/src/gcodecommands.cpp
+++ b/src/gcodecommands.cpp
@@ -508,20 +508,20 @@ QString toCommand(MCommands gcode, const QString &value1, const QString &value2)
         if (!value2.isEmpty()) {
             return QStringLiteral("M104 P%1 S%2").arg(value1).arg(value2);
         } else if (!value1.isEmpty()) {
-                return QStringLiteral("M104 S%1").arg(value1);
+            return QStringLiteral("M104 S%1").arg(value1);
         } else {
-                return QObject::tr("ERROR! M104: It's obligatory have an argument");
+            return QObject::tr("ERROR! M104: It's obligatory have an argument");
         }
     }
     case M105:
         return QStringLiteral("M105");
-    case M106:{
+    case M106: {
         if (!value2.isEmpty()) {
             return QStringLiteral("M106 P%1 S%2").arg(value1).arg(value2);
         } else if (!value1.isEmpty()) {
-                return QStringLiteral("M106 S%1").arg(value1);
+            return QStringLiteral("M106 S%1").arg(value1);
         } else {
-                return QStringLiteral("M106");
+            return QStringLiteral("M106");
         }
     }
     case M107:

--- a/src/ifirmware.h
+++ b/src/ifirmware.h
@@ -3,6 +3,14 @@
 #include <QObject>
 #include <QString>
 
+struct PrinterStatus {
+    //TODO: expand extruderTemps to list for multiple extruders
+    float extruderTemp;
+    float extruderTargetTemp;
+    float bedTemp;
+    float bedTargetTemp;
+};
+
 class IFirmware
 {
 public:
@@ -11,14 +19,9 @@ public:
     virtual QByteArray translate(const QString &command) = 0;
     virtual ~IFirmware() {}
     // ADD THE METHODS HERE.
-
-    struct {
-        //TODO: expand extruderTemps to list for multiple extruders
-        float extruderTemp;
-        float extruderTargetTemp;
-        float bedTemp;
-        float bedTargetTemp;
-    } PrinterStatus;
+    PrinterStatus printerStatus;
+signals:
+    void printerStatusChanged(const PrinterStatus &newStatus);
 };
 
 Q_DECLARE_INTERFACE(IFirmware, "org.kde.atelier.core.firmware")

--- a/src/ifirmware.h
+++ b/src/ifirmware.h
@@ -11,8 +11,9 @@ struct PrinterStatus {
     float bedTargetTemp;
 };
 
-class IFirmware
+class IFirmware : public QObject
 {
+    Q_OBJECT
 public:
     virtual QString name() const = 0;
     virtual bool readyForNextCommand(const QString &lastMessage) = 0;

--- a/src/plugins/aprinterplugin.cpp
+++ b/src/plugins/aprinterplugin.cpp
@@ -14,7 +14,7 @@ QString AprinterPlugin::name() const
     return QStringLiteral("Aprinter");
 }
 
-AprinterPlugin::AprinterPlugin(QObject *parent) : QObject(parent)
+AprinterPlugin::AprinterPlugin()
 {
     qCDebug(APRINTER_PLUGIN) << name() << " plugin loaded!";
 }

--- a/src/plugins/aprinterplugin.cpp
+++ b/src/plugins/aprinterplugin.cpp
@@ -24,16 +24,15 @@ void AprinterPlugin::extractTemp(const QString &lastMessage)
     // ok T:185.4 /185.0 B:60.5 /60.0
     QStringList list = lastMessage.split(QChar::fromLatin1(' '));
     // T:185.4 - current temperature
-    PrinterStatus.extruderTemp = list[0].mid(2).toFloat();
+    printerStatus.extruderTemp = list[0].mid(2).toFloat();
     // /185.0 - target temperature
-    PrinterStatus.extruderTargetTemp = list[1].mid(1).toFloat();
+    printerStatus.extruderTargetTemp = list[1].mid(1).toFloat();
     // B:185.4 - current temperature
-    PrinterStatus.bedTemp = list[2].mid(2).toFloat();
+    printerStatus.bedTemp = list[2].mid(2).toFloat();
     // /60.0 - target temperature
-    PrinterStatus.bedTargetTemp = list[3].mid(1).toFloat();
+    printerStatus.bedTargetTemp = list[3].mid(1).toFloat();
 
-    qCDebug(APRINTER_PLUGIN) << "Extruder" << PrinterStatus.extruderTemp << "/" << PrinterStatus.extruderTargetTemp;
-    qCDebug(APRINTER_PLUGIN) << "Bed" << PrinterStatus.bedTemp << "/" << PrinterStatus.bedTargetTemp;
+    emit(printerStatusChanged(printerStatus));
 }
 
 bool AprinterPlugin::validateCommand(const QString &lastMessage)

--- a/src/plugins/aprinterplugin.h
+++ b/src/plugins/aprinterplugin.h
@@ -20,4 +20,6 @@ public:
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
+signals:
+    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/src/plugins/aprinterplugin.h
+++ b/src/plugins/aprinterplugin.h
@@ -3,7 +3,7 @@
 #include "ifirmware.h"
 #include <QObject>
 
-class AprinterPlugin : public QObject, public IFirmware
+class AprinterPlugin : public IFirmware
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.kde.atelier.core.firmware" FILE "aprinter.json")
@@ -14,12 +14,10 @@ private:
     static QString _extruderTemp;
     static QString _bedTemp;
 public:
-    AprinterPlugin(QObject *parent = 0);
+    AprinterPlugin();
     QString name() const override;
     void extractTemp(const QString &lastMessage);
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
-signals:
-    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/src/plugins/grblplugin.cpp
+++ b/src/plugins/grblplugin.cpp
@@ -6,7 +6,7 @@ QString GrblPlugin::name() const
     return QStringLiteral("Grbl");
 }
 
-GrblPlugin::GrblPlugin(QObject *parent) : QObject(parent)
+GrblPlugin::GrblPlugin()
 {
 
 }

--- a/src/plugins/grblplugin.h
+++ b/src/plugins/grblplugin.h
@@ -3,13 +3,13 @@
 #include "ifirmware.h"
 #include <QObject>
 
-class GrblPlugin : public QObject, public IFirmware
+class GrblPlugin : public IFirmware
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.kde.atelier.core.firmware" FILE "grbl.json")
     Q_INTERFACES(IFirmware)
 public:
-    GrblPlugin(QObject *parent = nullptr);
+    GrblPlugin();
     QString name() const override;
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);

--- a/src/plugins/marlinplugin.cpp
+++ b/src/plugins/marlinplugin.cpp
@@ -24,16 +24,15 @@ void MarlinPlugin::extractTemp(const QString &lastMessage)
     // ok T:185.4 /185.0 B:60.5 /60.0
     QStringList list = lastMessage.split(QChar::fromLatin1(' '));
     // T:185.4 - current temperature
-    PrinterStatus.extruderTemp = list[0].mid(2).toFloat();
+    printerStatus.extruderTemp = list[0].mid(2).toFloat();
     // /185.0 - target temperature
-    PrinterStatus.extruderTargetTemp = list[1].mid(1).toFloat();
+    printerStatus.extruderTargetTemp = list[1].mid(1).toFloat();
     // B:185.4 - current temperature
-    PrinterStatus.bedTemp = list[2].mid(2).toFloat();
+    printerStatus.bedTemp = list[2].mid(2).toFloat();
     // /60.0 - target temperature
-    PrinterStatus.bedTargetTemp = list[3].mid(1).toFloat();
+    printerStatus.bedTargetTemp = list[3].mid(1).toFloat();
 
-    qCDebug(MARLIN_PLUGIN) << "Extruder" << PrinterStatus.extruderTemp << "/" << PrinterStatus.extruderTargetTemp;
-    qCDebug(MARLIN_PLUGIN) << "Bed" << PrinterStatus.bedTemp << "/" << PrinterStatus.bedTargetTemp;
+    emit(printerStatusChanged(printerStatus));
 }
 
 bool MarlinPlugin::validateCommand(const QString &lastMessage)

--- a/src/plugins/marlinplugin.cpp
+++ b/src/plugins/marlinplugin.cpp
@@ -14,7 +14,7 @@ QString MarlinPlugin::name() const
     return QStringLiteral("Marlin");
 }
 
-MarlinPlugin::MarlinPlugin(QObject *parent) : QObject(parent)
+MarlinPlugin::MarlinPlugin()
 {
     qCDebug(MARLIN_PLUGIN) << name() << " plugin loaded!";
 }

--- a/src/plugins/marlinplugin.h
+++ b/src/plugins/marlinplugin.h
@@ -3,7 +3,7 @@
 #include "ifirmware.h"
 #include <QObject>
 
-class MarlinPlugin : public QObject, public IFirmware
+class MarlinPlugin : public IFirmware
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.kde.atelier.core.firmware" FILE "marlin.json")
@@ -14,12 +14,10 @@ private:
     static QString _extruderTemp;
     static QString _bedTemp;
 public:
-    MarlinPlugin(QObject *parent = 0);
+    MarlinPlugin();
     QString name() const override;
     void extractTemp(const QString &lastMessage);
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
-signals:
-    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/src/plugins/marlinplugin.h
+++ b/src/plugins/marlinplugin.h
@@ -20,4 +20,6 @@ public:
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
+signals:
+    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/src/plugins/repetierplugin.cpp
+++ b/src/plugins/repetierplugin.cpp
@@ -14,7 +14,7 @@ QString RepetierPlugin::name() const
     return QStringLiteral("Repetier");
 }
 
-RepetierPlugin::RepetierPlugin(QObject *parent) : QObject(parent)
+RepetierPlugin::RepetierPlugin()
 {
     qCDebug(REPETIER_PLUGIN) << name() << " plugin loaded!";
 }

--- a/src/plugins/repetierplugin.cpp
+++ b/src/plugins/repetierplugin.cpp
@@ -24,16 +24,15 @@ void RepetierPlugin::extractTemp(const QString &lastMessage)
     // ok T:185.4 /185.0 B:60.5 /60.0
     QStringList list = lastMessage.split(QChar::fromLatin1(' '));
     // T:185.4 - current temperature
-    PrinterStatus.extruderTemp = list[0].mid(2).toFloat();
+    printerStatus.extruderTemp = list[0].mid(2).toFloat();
     // /185.0 - target temperature
-    PrinterStatus.extruderTargetTemp = list[1].mid(1).toFloat();
+    printerStatus.extruderTargetTemp = list[1].mid(1).toFloat();
     // B:185.4 - current temperature
-    PrinterStatus.bedTemp = list[2].mid(2).toFloat();
+    printerStatus.bedTemp = list[2].mid(2).toFloat();
     // /60.0 - target temperature
-    PrinterStatus.bedTargetTemp = list[3].mid(1).toFloat();
+    printerStatus.bedTargetTemp = list[3].mid(1).toFloat();
 
-    qCDebug(REPETIER_PLUGIN) << "Extruder" << PrinterStatus.extruderTemp << "/" << PrinterStatus.extruderTargetTemp;
-    qCDebug(REPETIER_PLUGIN) << "Bed" << PrinterStatus.bedTemp << "/" << PrinterStatus.bedTargetTemp;
+    emit(printerStatusChanged(printerStatus));
 }
 
 bool RepetierPlugin::validateCommand(const QString &lastMessage)

--- a/src/plugins/repetierplugin.h
+++ b/src/plugins/repetierplugin.h
@@ -20,4 +20,6 @@ public:
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
+signals:
+    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/src/plugins/repetierplugin.h
+++ b/src/plugins/repetierplugin.h
@@ -3,7 +3,7 @@
 #include "ifirmware.h"
 #include <QObject>
 
-class RepetierPlugin : public QObject, public IFirmware
+class RepetierPlugin : public IFirmware
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.kde.atelier.core.firmware" FILE "repetier.json")
@@ -14,12 +14,10 @@ private:
     static QString _extruderTemp;
     static QString _bedTemp;
 public:
-    RepetierPlugin(QObject *parent = nullptr);
+    RepetierPlugin();
     QString name() const override;
     void extractTemp(const QString &lastMessage);
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
-signals:
-    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/src/plugins/sprinterplugin.cpp
+++ b/src/plugins/sprinterplugin.cpp
@@ -24,16 +24,15 @@ void SprinterPlugin::extractTemp(const QString &lastMessage)
     // ok T:185.4 /185.0 B:60.5 /60.0
     QStringList list = lastMessage.split(QChar::fromLatin1(' '));
     // T:185.4 - current temperature
-    PrinterStatus.extruderTemp = list[0].mid(2).toFloat();
+    printerStatus.extruderTemp = list[0].mid(2).toFloat();
     // /185.0 - target temperature
-    PrinterStatus.extruderTargetTemp = list[1].mid(1).toFloat();
+    printerStatus.extruderTargetTemp = list[1].mid(1).toFloat();
     // B:185.4 - current temperature
-    PrinterStatus.bedTemp = list[2].mid(2).toFloat();
+    printerStatus.bedTemp = list[2].mid(2).toFloat();
     // /60.0 - target temperature
-    PrinterStatus.bedTargetTemp = list[3].mid(1).toFloat();
+    printerStatus.bedTargetTemp = list[3].mid(1).toFloat();
 
-    qCDebug(SPRINTER_PLUGIN) << "Extruder" << PrinterStatus.extruderTemp << "/" << PrinterStatus.extruderTargetTemp;
-    qCDebug(SPRINTER_PLUGIN) << "Bed" << PrinterStatus.bedTemp << "/" << PrinterStatus.bedTargetTemp;
+    emit(printerStatusChanged(printerStatus));
 }
 
 bool SprinterPlugin::validateCommand(const QString &lastMessage)

--- a/src/plugins/sprinterplugin.cpp
+++ b/src/plugins/sprinterplugin.cpp
@@ -14,7 +14,7 @@ QString SprinterPlugin::name() const
     return QStringLiteral("Sprinter");
 }
 
-SprinterPlugin::SprinterPlugin(QObject *parent) : QObject(parent)
+SprinterPlugin::SprinterPlugin()
 {
     qCDebug(SPRINTER_PLUGIN) << name() << " plugin loaded!";
 }

--- a/src/plugins/sprinterplugin.h
+++ b/src/plugins/sprinterplugin.h
@@ -3,7 +3,7 @@
 #include "ifirmware.h"
 #include <QObject>
 
-class SprinterPlugin : public QObject, public IFirmware
+class SprinterPlugin : public IFirmware
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.kde.atelier.core.firmware" FILE "sprinter.json")
@@ -14,12 +14,10 @@ private:
     static QString _extruderTemp;
     static QString _bedTemp;
 public:
-    SprinterPlugin(QObject *parent = 0);
+    SprinterPlugin();
     QString name() const override;
     void extractTemp(const QString &lastMessage);
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
-signals:
-    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/src/plugins/sprinterplugin.h
+++ b/src/plugins/sprinterplugin.h
@@ -20,4 +20,6 @@ public:
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
+signals:
+    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/src/plugins/teacupplugin.cpp
+++ b/src/plugins/teacupplugin.cpp
@@ -14,7 +14,7 @@ QString TeacupPlugin::name() const
     return QStringLiteral("Teacup");
 }
 
-TeacupPlugin::TeacupPlugin(QObject *parent) : QObject(parent)
+TeacupPlugin::TeacupPlugin()
 {
     qCDebug(TEACUP_PLUGIN) << name() << " plugin loaded!";
 }

--- a/src/plugins/teacupplugin.cpp
+++ b/src/plugins/teacupplugin.cpp
@@ -24,16 +24,15 @@ void TeacupPlugin::extractTemp(const QString &lastMessage)
     // ok T:185.4 /185.0 B:60.5 /60.0
     QStringList list = lastMessage.split(QChar::fromLatin1(' '));
     // T:185.4 - current temperature
-    PrinterStatus.extruderTemp = list[0].mid(2).toFloat();
+    printerStatus.extruderTemp = list[0].mid(2).toFloat();
     // /185.0 - target temperature
-    PrinterStatus.extruderTargetTemp = list[1].mid(1).toFloat();
+    printerStatus.extruderTargetTemp = list[1].mid(1).toFloat();
     // B:185.4 - current temperature
-    PrinterStatus.bedTemp = list[2].mid(2).toFloat();
+    printerStatus.bedTemp = list[2].mid(2).toFloat();
     // /60.0 - target temperature
-    PrinterStatus.bedTargetTemp = list[3].mid(1).toFloat();
+    printerStatus.bedTargetTemp = list[3].mid(1).toFloat();
 
-    qCDebug(TEACUP_PLUGIN) << "Extruder" << PrinterStatus.extruderTemp << "/" << PrinterStatus.extruderTargetTemp;
-    qCDebug(TEACUP_PLUGIN) << "Bed" << PrinterStatus.bedTemp << "/" << PrinterStatus.bedTargetTemp;
+    emit(printerStatusChanged(printerStatus));
 }
 
 bool TeacupPlugin::validateCommand(const QString &lastMessage)

--- a/src/plugins/teacupplugin.h
+++ b/src/plugins/teacupplugin.h
@@ -3,7 +3,7 @@
 #include "ifirmware.h"
 #include <QObject>
 
-class TeacupPlugin : public QObject, public IFirmware
+class TeacupPlugin : public IFirmware
 {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.kde.atelier.core.firmware" FILE "teacup.json")
@@ -14,12 +14,10 @@ private:
     static QString _extruderTemp;
     static QString _bedTemp;
 public:
-    TeacupPlugin(QObject *parent = nullptr);
+    TeacupPlugin();
     QString name() const override;
     void extractTemp(const QString &lastMessage);
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
-signals:
-    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/src/plugins/teacupplugin.h
+++ b/src/plugins/teacupplugin.h
@@ -20,4 +20,6 @@ public:
     bool validateCommand(const QString &lastMessage);
     bool readyForNextCommand(const QString &lastMessage);
     QByteArray translate(const QString &command);
+signals:
+    void printerStatusChanged(const PrinterStatus &newStatus);
 };

--- a/testclient/mainwindow.cpp
+++ b/testclient/mainwindow.cpp
@@ -274,12 +274,17 @@ void MainWindow::printPBClicked()
         break;
 
     case BUSY:
-        core->setState(PAUSE);
+        core->pause();
+        core->setRelativePosition();
+        core->pushCommand(GCode::toCommand(GCode::G1, QString::fromLatin1("Z1")));
+        core->setAbsolutePosition();
+        core->pushCommand(GCode::toCommand(GCode::G0, QString::fromLatin1("X0 Y195")));
         break;
 
     case PAUSE:
-        core->setState(BUSY);
+        core->resume();
         break;
+
     default:
         qDebug() << "ERROR / STOP unhandled.";
     }

--- a/testclient/mainwindow.cpp
+++ b/testclient/mainwindow.cpp
@@ -52,6 +52,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(core, &AtCore::stateChanged, this, &MainWindow::printerStateChanged);
     connect(this, &MainWindow::printFile, core, &AtCore::print);
     connect(ui->stopPB, &QPushButton::clicked, core, &AtCore::stop);
+    connect(core, &AtCore::printerStatusChanged, this, &MainWindow::checkPrinterStatus);
 }
 
 MainWindow::~MainWindow()
@@ -129,6 +130,16 @@ void MainWindow::checkPushedCommands(QByteArray bmsg)
     msg.replace(_newLine, QStringLiteral("\\n"));
     msg.replace(_return, QStringLiteral("\\r"));
     addSLog(msg);
+}
+
+void MainWindow::checkPrinterStatus(PrinterStatus status)
+{
+    QString msg = QString::fromLatin1("Bed:%1/%2  Extruder:%3/%4")
+                  .arg(QString::number(status.bedTemp))
+                  .arg(QString::number(status.bedTargetTemp))
+                  .arg(QString::number(status.extruderTemp))
+                  .arg(QString::number(status.extruderTargetTemp));
+    addRLog(msg);
 }
 /**
  * @brief MainWindow::locateSerialPort

--- a/testclient/mainwindow.cpp
+++ b/testclient/mainwindow.cpp
@@ -241,7 +241,13 @@ void MainWindow::extTempPBClicked()
 void MainWindow::mvAxisPBClicked()
 {
     addSLog(GCode::toString(GCode::G1));
-    core->pushCommand(GCode::toCommand(GCode::G1, ui->mvAxisCB->currentText().at(5) + ui->mvAxisSB->cleanText()));
+    if (ui->mvAxisCB->currentIndex() == 0) {
+        core->move(X, ui->mvAxisSB->value());
+    } else if (ui->mvAxisCB->currentIndex() == 1) {
+        core->move(Y, ui->mvAxisSB->value());
+    } else if (ui->mvAxisCB->currentIndex() == 2) {
+        core->move(Z, ui->mvAxisSB->value());
+    }
 }
 
 void MainWindow::fanSpeedPBClicked()

--- a/testclient/mainwindow.cpp
+++ b/testclient/mainwindow.cpp
@@ -194,37 +194,37 @@ void MainWindow::sendPBClicked()
 void MainWindow::homeAllPBClicked()
 {
     addSLog(tr("Home All"));
-    core->pushCommand(GCode::toCommand(GCode::G28));
+    core->home();
 }
 
 void MainWindow::homeXPBClicked()
 {
     addSLog(tr("Home X"));
-    core->pushCommand(GCode::toCommand(GCode::G28, QStringLiteral("X0")));
+    core->home(X);
 }
 
 void MainWindow::homeYPBClicked()
 {
     addSLog(tr("Home Y"));
-    core->pushCommand(GCode::toCommand(GCode::G28, QStringLiteral("Y0")));
+    core->home(Y);
 }
 
 void MainWindow::homeZPBClicked()
 {
     addSLog(tr("Home Z"));
-    core->pushCommand(GCode::toCommand(GCode::G28, QStringLiteral("Z0")));
+    core->home(Z);
 }
 
 void MainWindow::bedTempPBClicked()
 {
     addSLog(GCode::toString(GCode::M140));
-    core->pushCommand(GCode::toCommand(GCode::M140, ui->bedTempSB->cleanText()));
+    core->setBedTemp(ui->bedTempSB->value());
 }
 
 void MainWindow::extTempPBClicked()
 {
     addSLog(GCode::toString(GCode::M104));
-    core->pushCommand(GCode::toCommand(GCode::M104, ui->extTempSelCB->currentText().at(9), ui->extTempSB->cleanText()));
+    core->setExtruderTemp(ui->extTempSB->value(), ui->extTempSelCB->currentIndex());
 }
 
 void MainWindow::mvAxisPBClicked()
@@ -236,7 +236,7 @@ void MainWindow::mvAxisPBClicked()
 void MainWindow::fanSpeedPBClicked()
 {
     addSLog(GCode::toString(GCode::M106));
-    core->pushCommand(GCode::toCommand(GCode::M106, ui->fanSpeedSelCB->currentText().at(4), ui->fanSpeedSB->cleanText()));
+    core->setFanSpeed(ui->fanSpeedSB->value(), ui->fanSpeedSelCB->currentIndex());
 }
 
 void MainWindow::printPBClicked()

--- a/testclient/mainwindow.h
+++ b/testclient/mainwindow.h
@@ -34,6 +34,8 @@ public slots:
      */
     void checkPushedCommands(QByteArray);
 
+    void checkPrinterStatus(PrinterStatus);
+
 private slots:
     //ButtonEvents
     /**


### PR DESCRIPTION
Add all of  the test gui commands as slots within AtCore. 
Create signal for the plugins to return "PrinterStatus" data with temps.
Improve the pause and resume by tracking the heads placment when pausing and restoring it when resuming the printjob. 
setPrinterSpeed, setFlowRate, and move are now added also. 
Update the testgui to use new AtCore Features
