### PR TITLE
Add step install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.0)
 
 find_package(ECM REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH})
+option(BUILD_TEST_CLIENT "Build test client" OFF)
 
 include(KDECompilerSettings)
 include(KDEInstallDirs)
@@ -43,7 +44,8 @@ find_package(Qt5 REQUIRED COMPONENTS
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(src)
-add_subdirectory(testclient)
-
+if(BUILD_TEST_CLIENT)
+    add_subdirectory(testclient)
+endif()
 feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES FATAL_ON_MISSING_REQUIRED_PACKAGES)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,5 +7,7 @@ set(AtCoreLib_SRCS
     ifirmware.h
 )
 
-add_library(AtCoreLib STATIC ${AtCoreLib_SRCS})
+add_library(AtCoreLib SHARED ${AtCoreLib_SRCS})
 target_link_libraries(AtCoreLib Qt5::Core Qt5::SerialPort)
+
+install(TARGETS AtCoreLib LIBRARY DESTINATION lib/atcore)

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -29,3 +29,7 @@ set(AprinterPlugin_SRCS aprinterplugin.cpp)
 add_library(aprinter SHARED ${AprinterPlugin_SRCS})
 target_link_libraries(aprinter Qt5::Core AtCoreLib)
 add_dependencies(aprinter AtCoreLib)
+
+install( TARGETS repetier grbl marlin teacup sprinter aprinter
+         LIBRARY DESTINATION ${PLUGINDIR}/atcore/plugins
+        )


### PR DESCRIPTION
Include step install for sources and plugins of atcore.
Based on the doc of CMake, it will install the
sources in default places defined by the macros that
was used.

Signed-off-by: Lays Rodrigues <laysrodriguessilva@gmail.com>