### PR TITLE
Use installation folder to grep for plugin

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,10 @@
 add_subdirectory(plugins)
 
+configure_file(
+    atcore_default_folders.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/atcore_default_folders.h
+)
+
 set(AtCoreLib_SRCS
     atcore.cpp
     seriallayer.cpp
@@ -31,6 +36,7 @@ ecm_generate_headers(KATCORE_HEADERS
 
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/katcore_export.h
+    ${CMAKE_CURRENT_BINARY_DIR}/atcore_default_folders.h
     ${KATCORE_HEADERS}
     DESTINATION ${KDE_INSTALL_INCLUDEDIR_KF5}/KAtCore COMPONENT Devel
 )

--- a/src/atcore.cpp
+++ b/src/atcore.cpp
@@ -1,6 +1,7 @@
 #include "atcore.h"
 #include "seriallayer.h"
 #include "gcodecommands.h"
+#include "atcore_default_folders.h"
 
 #include <QDir>
 #include <QSerialPortInfo>
@@ -28,7 +29,7 @@ AtCore::AtCore(QObject *parent) :
     posString(QByteArray())
 {
     setState(DISCONNECTED);
-    d->pluginsDir = QDir(qApp->applicationDirPath());
+    d->pluginsDir = QDir(AtCoreDirectories::pluginDir);
 
 #if defined(Q_OS_WIN)
     if (d->pluginsDir.dirName().toLower() == "debug" || d->pluginsDir.dirName().toLower() == "release") {

--- a/src/atcore_default_folders.h.in
+++ b/src/atcore_default_folders.h.in
@@ -1,0 +1,8 @@
+#ifndef ATCORE_DEFAULT_FOLDERS_H
+#define ATCORE_DEFAULT_FOLDERS_H
+
+namespace AtCoreDirectories {
+    const QString pluginDir = QStringLiteral("@CMAKE_INSTALL_PREFIX@/@KDE_INSTALL_PLUGINDIR@/KAtCore");
+};
+
+#endif

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -23,3 +23,15 @@ target_link_libraries(sprinter Qt5::Core KF5::AtCore)
 set(AprinterPlugin_SRCS aprinterplugin.cpp)
 add_library(aprinter SHARED ${AprinterPlugin_SRCS})
 target_link_libraries(aprinter Qt5::Core KF5::AtCore)
+
+install(
+TARGETS
+    repetier
+    grbl
+    teacup
+    marlin
+    sprinter
+    aprinter
+DESTINATION
+    ${KDE_INSTALL_PLUGINDIR}/KAtCore
+)


### PR DESCRIPTION
We needed a way to get the Plugin Folder and use it to load the plugins,
this code is untested - I don't have a printer to try.

We should port this code to KServices.

Signed-off-by: Tomaz Canabrava <tcanabrava@kde.org>