### PR TITLE
Fix install

### DIFF
--- a/src/atcore_default_folders.h.in
+++ b/src/atcore_default_folders.h.in
@@ -1,6 +1,6 @@
 #pragma once
 
 namespace AtCoreDirectories {
-    const QString pluginDir = QStringLiteral("@CMAKE_INSTALL_PREFIX@/@KDE_INSTALL_PLUGINDIR@/KAtCore");
+    const QString pluginDir = QStringLiteral("@KDE_INSTALL_PLUGINDIR@/KAtCore");
 };
 


### PR DESCRIPTION
This will fix installed version finding the plugins correctly.  
Removed "@CMAKE_INSTALL_PREFIX@/" from path returned by AtCoreDirectories. 

old plugin search path :  `/usr/lib/plugins/qt/KAtCore/`  
new plugin search path : `/usr//usr/lib/plugins/qt/KAtCore/`

I Use this cmake command: 
`cmake -DCMAKE_INSTALL_PREFIX=$(kf5-config --prefix) -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release CMakeLists.txt `